### PR TITLE
fix index misalignment on playlist when shaffle mode

### DIFF
--- a/final/lib/services/audio_handler.dart
+++ b/final/lib/services/audio_handler.dart
@@ -77,7 +77,7 @@ class MyAudioHandler extends BaseAudioHandler {
       final newQueue = queue.value;
       if (index == null || newQueue.isEmpty) return;
       if (_player.shuffleModeEnabled) {
-        index = _player.shuffleIndices![index];
+        index = _player.shuffleIndices!.indexOf(index);
       }
       final oldMediaItem = newQueue[index];
       final newMediaItem = oldMediaItem.copyWith(duration: duration);
@@ -92,7 +92,7 @@ class MyAudioHandler extends BaseAudioHandler {
       final playlist = queue.value;
       if (index == null || playlist.isEmpty) return;
       if (_player.shuffleModeEnabled) {
-        index = _player.shuffleIndices![index];
+        index = _player.shuffleIndices!.indexOf(index);
       }
       mediaItem.add(playlist[index]);
     });


### PR DESCRIPTION
I was able to solve the problems already noted.
The cause seems to be that the values needed in the shuffleIndices list were reversed for indexes and elements.

I am not used to English and PR so I apologize if I am wrong about something.

#20